### PR TITLE
feat: add KubeStellar Console to Dashboard section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ awesome-observability/
 ├── configs/                     # Configuration templates
 │   ├── .env.template           # Environment variables template
 │   └── grafana-dashboard.json  # Pre-built Grafana dashboard
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and CNCF project integrations across edge and cloud clusters.
 │
 └── tests/                       # Test suite (if included)
 ```


### PR DESCRIPTION
[KubeStellar Console](https://github.com/kubestellar/console) is an open-source multi-cluster Kubernetes dashboard — CNCF Sandbox project with AI-powered operations, 20+ CNCF integrations (Argo, Kyverno, Istio, Prometheus), and real-time observability across edge and cloud.\n\n*Happy to adjust description or placement.*